### PR TITLE
fix: migration table name missmatch

### DIFF
--- a/Migrations/AddSliderAlignmentMigration.cs
+++ b/Migrations/AddSliderAlignmentMigration.cs
@@ -9,8 +9,9 @@ namespace Nop.Plugin.Widgets.qBoSlider.Migrations
     {
         public override void Up()
         {
+            var tableName = NameCompatibilityManager.GetTableName(typeof(WidgetZone));
             Create.Column(nameof(WidgetZone.SliderAlignmentId))
-            .OnTable(nameof(WidgetZone))
+            .OnTable(tableName)
             .AsInt32()
             .NotNullable()
             .WithDefaultValue(5);


### PR DESCRIPTION
Migration was trying to update table "WidgetZone" wich does not exist.